### PR TITLE
fix: resolve game ending immediately on start

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,9 +136,9 @@
                 return;
             }
             
-            // Check self collision
-            for (let segment of snake) {
-                if (head.x === segment.x && head.y === segment.y) {
+            // Check self collision (exclude head, only check body segments)
+            for (let i = 1; i < snake.length; i++) {
+                if (head.x === snake[i].x && head.y === snake[i].y) {
                     gameOver();
                     return;
                 }


### PR DESCRIPTION
Fixes #8

This PR resolves the intermittent bug where the Snake game would end immediately upon starting.

## Problem
The self-collision detection was checking if the new head position collided with ANY snake segment, including the current head itself. When the game started with no movement (dx = 0, dy = 0), this created a false positive collision.

## Solution
Modified the collision detection to only check against body segments (excluding the head), preventing the snake from "colliding with itself" when stationary.

## Changes
- Updated self-collision logic in `index.html` to start loop from index 1 instead of 0
- Added explanatory comment for clarity

Generated with [Claude Code](https://claude.ai/code)